### PR TITLE
Rails 5 syntax change

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,4 +1,8 @@
 class Link < ActiveRecord::Base
+  # For ruby tutorial purposes. In Authentication Chapter, when connecting users to links, 
+  # Error message 'ActiveRecord::RecordInvalid (Validation failed: User must exist):'
+  # If you're on Rails 5, you'll need to update your user association to:
+  # belongs_to :user, optional: true
   belongs_to :user, validate: true
 
   has_many :votes, dependent: :destroy


### PR DESCRIPTION
For Ruby tutorial, if using Rails 5, firing up graphiql will throw syntax error.
--trace
```ActiveRecord::RecordInvalid (Validation failed: User must exist):
app/graphql/resolvers/create_link.rb:14:in `call'
app/controllers/graphql_controller.rb:11:in `execute'```
Resource here: `https://github.com/ankane/ahoy/issues/215`