### PR TITLE
updated normalize_filters

### DIFF
--- a/app/graphql/resolvers/links_search.rb
+++ b/app/graphql/resolvers/links_search.rb
@@ -31,8 +31,8 @@ class Resolvers::LinksSearch
 
   def normalize_filters(value, branches = [])
     scope = Link.all
-    scope = scope.like(:description, value['description_contains']) if value['description_contains']
-    scope = scope.like(:url, value['url_contains']) if value['url_contains']
+    scope = scope.like(:description, value[:description_contains]) if value[:description_contains]
+    scope = scope.like(:url, value[:url_contains]) if value[:url_contains]
 
     branches << scope
 


### PR DESCRIPTION
normalize_filters didn't works using "description_contains" and "url_contains" as string, I had to change to use symbols :url_contains and :description_contains to get filter working as well. I'm using Rails 5.2.2.1 and ruby 2.6.2p47