### PR TITLE
Replace `.like` with `.where` to fix NoMethodError

### DIFF
--- a/app/graphql/resolvers/links_search.rb
+++ b/app/graphql/resolvers/links_search.rb
@@ -31,8 +31,8 @@ class Resolvers::LinksSearch
 
   def normalize_filters(value, branches = [])
     scope = Link.all
-    scope = scope.like(:description, value[:description_contains]) if value[:description_contains]
-    scope = scope.like(:url, value[:url_contains]) if value[:url_contains]
+    scope = scope.where("Description LIKE '%#{value[:description_contains]}%'") if value[:description_contains]
+    scope = scope.where("Url LIKE '%#{value[:url_contains]}%'") if value[:url_contains]
 
     branches << scope
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6130520/58607655-1d381300-8266-11e9-8bb8-6f824a963d59.png)

Steps to reproduce using Rails@5.2.3 and Ruby@2.6.3:
1. Open rails console (`rails console`)
2. Run `Link.all.like`
3. Confirm that you see a `NoMethodError (undefined method `like' for #<Link::ActiveRecord_Relation>)` error

Source: https://github.com/rails/rails/commit/8d02afeaee8993bd0fde69687fdd9bf30921e805