### PR TITLE
fix create user mutation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ mutation {
   createUser(
     name: "Radoslav Stankov",
     authProvider: {
-      email: { email: "rado@example.com", password: "123456" }
+      credentials: { email: "rado@example.com", password: "123456" }
     }
   ) {
     id

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Creates new user token:
 
 ```graphql
 mutation {
-  signinUser(email: {email: "rado@example.com", password: "123456"}) {
+  signinUser(credentials: {email: "rado@example.com", password: "123456"}) {
     token
     user {
       id


### PR DESCRIPTION
`authProvider` property doesn't have type `email`, it uses `credentials`