### PR TITLE
Upgrade mimemagic so gems can be installed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)


### PR DESCRIPTION
Upgrade to avoid following error while running `bundle install`:

```
Your bundle is locked to mimemagic (0.3.3), but that version could not be found
in any of the sources listed in your Gemfile. If you haven't changed sources,
that means the author of mimemagic (0.3.3) has removed it. You'll need to update
your bundle to a version other than mimemagic (0.3.3) that hasn't been removed
in order to install.
```